### PR TITLE
Any Timeout Gem; Tempfile Location Interface; v1.0.3;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
-## [1.0.2] - 2021-10-27
+## [1.0.3] - 2021-10-27
+
+### Added
+
+-
 
 ### Changed
 
-- Lock timeout gem to 0.1.x
-- Ensure rake is required when loading railtie tasks.
+- Remove timeout version lock.
 
-## [1.0.1] - 2021-07-24
+## [1.0.2] - 2021-07-24
 
 ### Changed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: .
   specs:
-    lambda_punch (1.0.2)
+    lambda_punch (1.0.3)
       concurrent-ruby
       rake
       rb-inotify
-      timeout (~> 0.1.1)
+      timeout
 
 GEM
   remote: https://rubygems.org/
@@ -137,7 +137,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     thor (1.1.0)
-    timeout (0.1.1)
+    timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     websocket-driver (0.7.5)

--- a/lambda_punch.gemspec
+++ b/lambda_punch.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "rake"
   spec.add_dependency "rb-inotify"
-  spec.add_dependency "timeout", "~> 0.1.1"
+  spec.add_dependency "timeout"
   spec.add_development_dependency "minitest-focus"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rails"

--- a/lib/lambda_punch.rb
+++ b/lib/lambda_punch.rb
@@ -58,6 +58,10 @@ module LambdaPunch
     @error_handler = func
   end
 
+  def tmp_file
+    Notifier.tmp_file
+  end
+
   extend self
 
 end

--- a/lib/lambda_punch/notifier.rb
+++ b/lib/lambda_punch/notifier.rb
@@ -15,6 +15,10 @@ module LambdaPunch
         File.read(FILE)
       end
 
+      def tmp_file
+        FILE
+      end
+
     end
 
     def initialize

--- a/lib/lambda_punch/version.rb
+++ b/lib/lambda_punch/version.rb
@@ -1,3 +1,3 @@
 module LambdaPunch
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/test/cases/notifier_test.rb
+++ b/test/cases/notifier_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class NotifierTest < LambdaPunchSpec
+
+  it 'has an accessor for the temp file' do
+    expect(LambdaPunch.tmp_file).must_equal '/tmp/lambdapunch-handled'
+  end
+
+end


### PR DESCRIPTION
Provide an interface to the tempfile used so it can be excluded from other's cleanup operations. So please use `LambdaPunch.tmp_file`.